### PR TITLE
fix repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "repository" :{
         "type" : "git",
-        "url" : "http://github.com/isaacs/npm.git"
+        "url" : "https://github.com/jmarca/openldap_ssha.git"
     },
     "devDependencies": {
         "mocha": "*",


### PR DESCRIPTION
This should make it so places like https://www.npmjs.com/package/openldap_ssha show the correct link.